### PR TITLE
Fix stats crash due to temp file

### DIFF
--- a/CommunityView/src/stats.py
+++ b/CommunityView/src/stats.py
@@ -355,7 +355,8 @@ def expire_stats(retain_days):
     """Retain the number of days of stats files specified by retain_days,
     if extant, and remove any stats files from earlier days."""
     files = os.listdir(statspath)
-    mobjs = [re.search(r"^(\d\d\d\d-\d\d-\d\d)_.*\.csv",f) for f in files]
+    # find stats files; the .* at the end of the re picks up stats .temp files
+    mobjs = [re.search(r"^(\d\d\d\d-\d\d-\d\d)_.*\.csv.*",f) for f in files]
     statsdates = sorted(list(set([m.group(1) for m in mobjs if m])))
     # if there are more stats file dates than the number we're supposed to
     # retain, delete the out-of-date files

--- a/CommunityView/src/test/testStats.py
+++ b/CommunityView/src/test/testStats.py
@@ -240,7 +240,7 @@ class TestStats(unittest.TestCase):
     def test030expire_stats(self):
         """Test to see that expire_stats deletes the correct files."""
         to_be_deleted = [
-            "2000-01-01_cam1.csv",
+            "2000-01-01_cam1.csv.temp",
             "2000-01-01_cam2.csv",
             "2000-01-02_cam1.csv",
             "2000-01-02_cam2.csv",
@@ -248,7 +248,7 @@ class TestStats(unittest.TestCase):
             "2000-01-02_.csv",
             ]
         to_be_retained = [
-            "2000-01-03_cam1.csv",
+            "2000-01-03_cam1.csv.temp",
             "2000-01-03_cam2.csv",
             "2000-01-04_cam1.csv",
             "2000-01-04_cam2.csv",


### PR DESCRIPTION
- Fix crash where stats code would crash on trying to remove temp
file due to wrong filename. This would cause all work to stop
even though CommunityView server was "running."
- Update stats tests for new fix.